### PR TITLE
Fix for split series that only return 1 result. Changes to make Max value a Green Light.

### DIFF
--- a/public/trafficlightvis.html
+++ b/public/trafficlightvis.html
@@ -4,12 +4,12 @@
 	        <div class="traffic-light-container" ng-style="{'width': vis.params.width+'px', 'height': (2.68 * vis.params.width)+'px' }">
 	            <div class="traffic-light">
 	                <div class="light red" ng-class="{'on':
-						(!vis.params.invertScale && ((metric.value <= vis.params.redThreshold) || (metric.value >= vis.params.max)))
+						(!vis.params.invertScale && ((metric.value <= vis.params.redThreshold) || (metric.value > vis.params.max)))
 						|| (vis.params.invertScale && metric.value >= vis.params.redThreshold) }">
 					</div>
 	                <div class="light yellow" ng-class="{'on': (!vis.params.invertScale && metric.value > vis.params.redThreshold && metric.value < vis.params.greenThreshold) || (vis.params.invertScale && metric.value < vis.params.redThreshold && metric.value > vis.params.greenThreshold) }"></div>
 	                <div class="light green" ng-class="{'on':
-					(!vis.params.invertScale && metric.value >= vis.params.greenThreshold && metric.value < vis.params.max)
+					(!vis.params.invertScale && metric.value >= vis.params.greenThreshold && metric.value <= vis.params.max)
 					|| (vis.params.invertScale && metric.value <= vis.params.greenThreshold) }"></div>
 	            </div>
 	        </div>

--- a/public/trafficlightviscontroller.js
+++ b/public/trafficlightviscontroller.js
@@ -1,18 +1,15 @@
 import {
     uiModules
 } from 'ui/modules';
+
 const module = uiModules.get('kibana/transform_vis', ['kibana']);
 
 module.controller('TrafficLightVisController', function ($scope, Private) {
     $scope.lines = [];
-
     $scope.percentperlight = 100;
-
-//    console.log("PercentPerLight=" + $scope.percentperlight);
 
     $scope.$watch('esResponse', function (resp) {
         if (resp) {
-//            console.log(resp);
             var columns = resp.columns;
             var rows = resp.rows;
 
@@ -29,20 +26,18 @@ module.controller('TrafficLightVisController', function ($scope, Private) {
 
             if ($scope.vis.params.numberOfLights > 0) {
                 $scope.percentperlight = 100 / $scope.vis.params.numberOfLights;
-//                console.log("Setting width traffic light width to:" + $scope.percentperlight);
             }
 
             for (var r in rows) {
                 var row = rows[r];
-//                console.log(r);
-//                console.log(row);
 
                 if (i % lightsperline == 0) {
                     metrics = [];
                     lines.push(metrics);
                 }
 
-                if (rows.length == 1) {
+                // Visualizations without series return col-0-1 with no label.
+                if (rows.length == 1 && "col-0-1" in row) {
                     metrics.push({
                         "label": "All",
                         "value": row["col-0-1"]


### PR DESCRIPTION
* When creating visualizations and using split series, if the series only returns 1 value the visualization shows nothing.

* When Max value equals the Green Minimum value the Red Light is used.